### PR TITLE
Platform Installer appears hung when installing the NServiceBus prerequisites.

### DIFF
--- a/src/PlatformInstaller/Installer.cs
+++ b/src/PlatformInstaller/Installer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Anotar.Serilog;
 using Caliburn.Micro;
 
 public class Installer : 
@@ -106,6 +107,7 @@ public class Installer :
             {
                 Text = output
             });
+        LogTo.Information(output);
     }
 
     void AddError(string error)
@@ -116,6 +118,7 @@ public class Installer :
                 Text = error
             });
         errors.Add(error);
+        LogTo.Error(error);
     }
 
     public void Handle(NestedInstallCompleteEvent message)


### PR DESCRIPTION
On a fresh Windows 10 machine I used the PI to install the NSB prerequisities,  
After only selecting the pre-requisites and pressing install the app locked up for the duration of the install of the prerequisites and showed no progress activity.  This took between 1 to 2 minutes.

Repeated the test on a fresh Windows 2012 R2 VM on azure.  Same result.

When this first happened I was about to kill the task as I thought it was dead.