### PR TITLE
Add "About our License Process" section to LicenseAgreementView

### DIFF
--- a/src/PlatformInstaller/Views/LicenseAgreementView.xaml
+++ b/src/PlatformInstaller/Views/LicenseAgreementView.xaml
@@ -18,8 +18,9 @@
     </UserControl.Resources>
     <DockPanel>
         <StackPanel DockPanel.Dock="Top" Orientation="Vertical" FlowDirection="LeftToRight">
-            <Label FontWeight="Bold" FontSize="18">About our License Process</Label>
-            <Label FontSize="16">Your initial trial lasts for 14 days, but after that you can instantly extend it for FREE.</Label>
+            <TextBlock FontSize="16" Margin="6">
+                Your initial trial lasts for 14 days. When the trial expires we'll provide instructions on how to extend it for <Bold>free</Bold>.
+            </TextBlock>
             <Label FontWeight="Bold" FontSize="18" Margin="0,18,0,0">Evaluation End User License Agreement</Label>
         </StackPanel>
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" FlowDirection="RightToLeft" >

--- a/src/PlatformInstaller/Views/LicenseAgreementView.xaml
+++ b/src/PlatformInstaller/Views/LicenseAgreementView.xaml
@@ -17,6 +17,11 @@
         </ResourceDictionary>
     </UserControl.Resources>
     <DockPanel>
+        <StackPanel DockPanel.Dock="Top" Orientation="Vertical" FlowDirection="LeftToRight">
+            <Label FontWeight="Bold" FontSize="18">About our License Process</Label>
+            <Label FontSize="16">Your initial trial lasts for 14 days, but after that you can instantly extend it for FREE.</Label>
+            <Label FontWeight="Bold" FontSize="18" Margin="0,18,0,0">Evaluation End User License Agreement</Label>
+        </StackPanel>
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" FlowDirection="RightToLeft" >
             <Button x:Name="Exit" Content="Exit"/>
             <Button x:Name="Copy" Content="Copy"/>


### PR DESCRIPTION
Connects to https://github.com/Particular/OptimizeTrialExtensions/issues/10, see specifically https://github.com/Particular/OptimizeTrialExtensions/issues/10#issuecomment-255761710

Be gentle with me, this is my very first foray of any kind into WPF or XAML.

With the change, the license agreement dialog looks like this:

![image](https://cloud.githubusercontent.com/assets/427110/19820687/09b5ce0e-9d20-11e6-981e-618ba9dee129.png)

Please review @Particular/serviceinsight-maintainers, cc @adamralph 
