### PR TITLE
Updating signing thumbprint

### DIFF
--- a/src/PlatformInstaller.ClickOnce/PlatformInstaller.ClickOnce.csproj
+++ b/src/PlatformInstaller.ClickOnce/PlatformInstaller.ClickOnce.csproj
@@ -74,7 +74,7 @@
   <Target Name="AfterBuild">
   
 	<PropertyGroup>
-      <ThumbPrint>BE71091FDBC50425DDAC13EDD5629B0A3B240985</ThumbPrint>
+      <ThumbPrint>28c81319c47f3afccb075cf5f97a58981972b73f</ThumbPrint>
       <Publisher>Particular Software</Publisher>
       <AppManifest>PlatformInstaller.exe.manifest</AppManifest>
       <ProdDeployManifest>PlatformInstaller.application</ProdDeployManifest>

--- a/src/PlatformInstaller/PlatformInstaller.csproj
+++ b/src/PlatformInstaller/PlatformInstaller.csproj
@@ -414,7 +414,7 @@
   <Target Name="AfterBuild" Condition=" '$(Configuration)' == 'Release' ">
     <!-- Thumbprint is for the NServiceBus Code Signing Certificate -->
     <PropertyGroup>
-      <Thumbprint>BE71091FDBC50425DDAC13EDD5629B0A3B240985</Thumbprint>
+      <Thumbprint>28c81319c47f3afccb075cf5f97a58981972b73f</Thumbprint>
       <TimeStampURL>http://timestamp.globalsign.com/scripts/timstamp.dll</TimeStampURL>
     </PropertyGroup>
     <SignFile CertificateThumbprint="$(Thumbprint)" SigningTarget="$(OutputPath)$(AssemblyName).exe" TimestampUrl="$(TimeStampURL)" />


### PR DESCRIPTION
The signing certificate is about to expire on December 22. A replacement has been installed on all the build agents. This is the thumbprint for the new one