### PR TITLE
SP installer always runs in interactive mode

### DIFF
--- a/src/PlatformInstaller/Installations/ServicePulseInstaller.cs
+++ b/src/PlatformInstaller/Installations/ServicePulseInstaller.cs
@@ -77,7 +77,7 @@ public class ServicePulseInstaller : IInstaller
         eventAggregator.PublishOnUIThread(new NestedInstallProgressEvent { Name = $"Executing {Name} installation" });
 
         var exitCode = await processRunner.RunProcess(installer.FullName,
-            $"/quiet /L*V {msiLog.QuoteForCommandline()}",
+            $"/L*V {msiLog.QuoteForCommandline()}",
             // ReSharper disable once PossibleNullReferenceException
             installer.Directory.FullName,
             logOutput,


### PR DESCRIPTION
## Overview
This change is caused by the current SP installation experience and problems it causes from monitoring instance feature.

Currently when users upgrade to newest version of SP and have any other installed the SP installer is run with `/quiet` flag and does not give the user a chance to configure monitoring instance url. As a result the users has to do it manually at the file system level.

This change always shows the installer which enables the user to check/change/specify configuration options on each update.