### PR TITLE
Add build metadata to FileVersion

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,3 +1,4 @@
 assembly-versioning-scheme: MajorMinorPatch
+assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{CommitsSinceVersionSource}'
 increment: Patch
 next-version: 1.0.2


### PR DESCRIPTION
This ensures that the 4 part of the FileVersion has a value. This matters since the ClickOnce app uses the FileVersion to version the manifest.

Without properly bumping the manifest, 2 deploys of the installer without manually bumping `next-version` patch version would result in a deploy that looks like the same version.

Looks like this has likely been an issue for quite a while.